### PR TITLE
95zfcp_rules/parse-zfcp.sh: remove rule existence check (bsc#1008352)

### DIFF
--- a/modules.d/95zfcp_rules/parse-zfcp.sh
+++ b/modules.d/95zfcp_rules/parse-zfcp.sh
@@ -22,8 +22,6 @@ create_udev_rule() {
         return 0;
     fi
 
-    [ -e ${_rule} ] && return 0
-
     if [ ! -f "$_rule" ] ; then
         cat > $_rule <<EOF
 ACTION=="add", SUBSYSTEM=="ccw", KERNEL=="$ccw", IMPORT{program}="collect $ccw %k ${ccw} zfcp"


### PR DESCRIPTION
Remove the check [ -e ${_rule} ] && return 0

as this would trigger for _any_ rule file if the rules are specified
with explicit WWPN and LUN numbers.