### PR TITLE
95iscsi: decouple iscsi from sysinit.target (boo#1134472)

### DIFF
--- a/modules.d/95iscsi/module-setup.sh
+++ b/modules.d/95iscsi/module-setup.sh
@@ -300,13 +300,13 @@ install() {
             echo "Conflicts=shutdown.target"
             echo "Before=shutdown.target sockets.target"
         ) > "${initdir}/$systemdsystemunitdir/iscsid.socket.d/dracut.conf"
-        mkdir -p "${initdir}/$systemdsystemunitdir/iscsuio.socket.d"
+        mkdir -p "${initdir}/$systemdsystemunitdir/iscsiuio.socket.d"
         (
             echo "[Unit]"
             echo "DefaultDependencies=no"
             echo "Conflicts=shutdown.target"
             echo "Before=shutdown.target sockets.target"
-        ) > "${initdir}/$systemdsystemunitdir/iscsuio.socket.d/dracut.conf"
+        ) > "${initdir}/$systemdsystemunitdir/iscsiuio.socket.d/dracut.conf"
 
     fi
     inst_dir /var/lib/iscsi

--- a/modules.d/95iscsi/module-setup.sh
+++ b/modules.d/95iscsi/module-setup.sh
@@ -291,6 +291,23 @@ install() {
             echo "After=dracut-cmdline.service"
             echo "Before=dracut-initqueue.service"
         ) > "${initdir}/$systemdsystemunitdir/iscsid.service.d/dracut.conf"
+
+        # The iscsi deamon does not need to wait for any storage inside initrd
+        mkdir -p "${initdir}/$systemdsystemunitdir/iscsid.socket.d"
+        (
+            echo "[Unit]"
+            echo "DefaultDependencies=no"
+            echo "Conflicts=shutdown.target"
+            echo "Before=shutdown.target sockets.target"
+        ) > "${initdir}/$systemdsystemunitdir/iscsid.socket.d/dracut.conf"
+        mkdir -p "${initdir}/$systemdsystemunitdir/iscsuio.socket.d"
+        (
+            echo "[Unit]"
+            echo "DefaultDependencies=no"
+            echo "Conflicts=shutdown.target"
+            echo "Before=shutdown.target sockets.target"
+        ) > "${initdir}/$systemdsystemunitdir/iscsuio.socket.d/dracut.conf"
+
     fi
     inst_dir /var/lib/iscsi
     dracut_need_initqueue


### PR DESCRIPTION
I didn't test this PR as-is, but copy-pasting the added section into a broken system and rebuilding the initrd made it work again.