### PR TITLE
90kernel-modules/module-setup.sh: fix typo

### DIFF
--- a/modules.d/90kernel-modules/module-setup.sh
+++ b/modules.d/90kernel-modules/module-setup.sh
@@ -42,7 +42,7 @@ installkernel() {
             ehci-hcd ehci-pci ehci-platform \
             ohci-hcd ohci-pci \
             uhci-hcd \
-            pwm-lpss pwm-lpss-platform
+            pwm-lpss pwm-lpss-platform \
             xhci-hcd xhci-pci xhci-plat-hcd \
             "=drivers/pinctrl" \
             ${NULL}


### PR DESCRIPTION
See bsc#1147124.