### PR TITLE
Add nvdimm and suse-initrd modules

### DIFF
--- a/modules.d/90kernel-modules/module-setup.sh
+++ b/modules.d/90kernel-modules/module-setup.sh
@@ -42,7 +42,7 @@ installkernel() {
             yenta_socket scsi_dh_rdac scsi_dh_emc scsi_dh_alua \
             atkbd i8042 usbhid firewire-ohci pcmcia hv-vmbus \
             virtio virtio_blk virtio_ring virtio_pci virtio_scsi \
-            "=drivers/pcmcia" =ide nvme vmd nfit
+            "=drivers/pcmcia" =ide nvme vmd
 
         if [[ "$(uname -m)" == arm* || "$(uname -m)" == aarch64 ]]; then
             # arm/aarch64 specific modules

--- a/modules.d/90nvdimm/module-setup.sh
+++ b/modules.d/90nvdimm/module-setup.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# called by dracut
+check() {
+    if [[ ! $hostonly ]]; then
+        return 0
+    fi
+    [[ $DRACUT_KERNEL_MODALIASES && -f "$DRACUT_KERNEL_MODALIASES" ]] && \
+        grep -q libnvdimm "$DRACUT_KERNEL_MODALIASES" && return 0
+    return 255
+}
+
+# called by dracut
+depends() {
+    return 0
+}
+
+# called by dracut
+installkernel() {
+    # Directories to search for NVDIMM "providers" (firmware drivers)
+    # These modules call "nvdimm_bus_register()".
+    local _provider_dirs='=drivers/nvdimm =drivers/acpi =arch/powerpc'
+
+    #instmods() will take care of hostonly
+    dracut_instmods -o -s nvdimm_bus_register $_provider_dirs
+}
+
+# called by dracut
+install() {
+    inst_multiple -o ndctl
+}

--- a/modules.d/99suse-initrd/module-setup.sh
+++ b/modules.d/99suse-initrd/module-setup.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# Parse SUSE kernel module dependencies
+#
+# Kernel modules using "request_module" function may not show up in modprobe
+# To worka round this, add depedencies in the following form:
+# # SUSE_INITRD: module_name REQUIRES module1 module2 ...
+# to /etc/modprobe.d/*.conf
+
+# called by dracut
+check() {
+    # Skip the module if no SUSE INITRD is used
+    grep -q "^# SUSE INITRD: " $(get_modprobe_conf_files)
+}
+
+get_modprobe_conf_files() {
+    ls /etc/modprobe.d/*.conf /run/modules.d/*.conf /lib/modules.d/*.conf \
+       2>/dev/null
+    return 0
+}
+
+# called by dracut
+installkernel() {
+    local line mod reqs all_mods=
+
+    while read -r line; do
+        mod="${line##*SUSE INITRD: }"
+        mod="${mod%% REQUIRES*}"
+        reqs="${line##*REQUIRES }"
+        if [[ ! $hostonly ]] || grep -q "^$mod\$" "$DRACUT_KERNEL_MODALIASES"
+        then
+            all_mods="$all_mods $reqs"
+        fi
+    done <<< "$(grep -h "^# SUSE INITRD: " $(get_modprobe_conf_files))"
+
+    # strip whitespace
+    all_mods="$(echo $all_mods)"
+    if [[ "$all_mods" ]]; then
+        dracut_instmods $all_mods
+    fi
+}


### PR DESCRIPTION
This adds the 90nvdimm and 99suse-initrd modules as discussed. I've done basic testing, it seems to work fine.

Difference to previous SUSE INITRD implementation: I look in all `.conf` files now (not only the ones starting with two digits) and I look in `/lib/modules.d` and `/run/modules.d`, too. The implementation has been simplified, no need to create a bash array as global variable.