### PR TITLE
Default DHCP fixes

### DIFF
--- a/modules.d/35network-legacy/ifup.sh
+++ b/modules.d/35network-legacy/ifup.sh
@@ -81,6 +81,12 @@ dhcp_wicked_apply() {
         if [ -n "${DNSSEARCH}" ]; then
             echo search "${DNSSEARCH}"
         fi >> /tmp/net.$netif.resolv.conf.ipv${1:1:1}
+
+        if  [ -n "${DNSSERVERS}" ] ; then
+            for s in ${DNSSERVERS}; do
+                echo nameserver "$s"
+            done
+        fi >> /tmp/net.$netif.resolv.conf.ipv${1:1:1}
     fi
     # copy resolv.conf if it doesn't exist yet, modify otherwise
     if [ -e /tmp/net.$netif.resolv.conf.ipv${1:1:1} ] && [ ! -e /etc/resolv.conf ]; then

--- a/modules.d/35network-legacy/ifup.sh
+++ b/modules.d/35network-legacy/ifup.sh
@@ -663,6 +663,12 @@ if [ -z "$NO_AUTO_DHCP" ] && [ ! -e /tmp/net.${netif}.up ]; then
             do_dhcp -4
         fi
     fi
+    if [ $? -eq 0 ] && [ -f /tmp/leaseinfo.${netif}* ]; then
+         > /tmp/net.${netif}.did-setup
+         if [ -e /sys/class/net/${netif}/address ]; then
+             > /tmp/net.$(cat /sys/class/net/${netif}/address).did-setup
+         fi
+    fi
 fi
 
 exit 0


### PR DESCRIPTION
- store nameserver received from leases file when constructing new resolv.conf
- mark interface setup finished when no `ip=` was not present on the command line and we drop to default dhcp setup