### PR TITLE
90nvdimm: include nvdimm keys in initrd

### DIFF
--- a/modules.d/90nvdimm/module-setup.sh
+++ b/modules.d/90nvdimm/module-setup.sh
@@ -27,5 +27,5 @@ installkernel() {
 
 # called by dracut
 install() {
-    inst_multiple -o ndctl
+    inst_multiple -o ndctl /etc/ndctl/keys/tpm.handle /etc/ndctl/keys/*.blob
 }


### PR DESCRIPTION
This is necessary to actually unlock NVDIMM keys during boot.

Upstream PR: https://github.com/dracutdevs/dracut/pull/775