### PR TITLE
network-legacy/net-genrules.sh: use $name instead of $env{INTERFACE}

### DIFF
--- a/modules.d/35network-legacy/net-genrules.sh
+++ b/modules.d/35network-legacy/net-genrules.sh
@@ -65,9 +65,9 @@ command -v fix_bootif >/dev/null || . /lib/net-lib.sh
         bootdev=$(cat /tmp/net.bootdev)
     fi
 
-    ifup='/sbin/ifup $env{INTERFACE}'
+    ifup='/sbin/ifup $name'
 
-    runcmd="RUN+=\"/sbin/initqueue --name ifup-\$env{INTERFACE} --unique --onetime $ifup\""
+    runcmd="RUN+=\"/sbin/initqueue --name ifup-\$name --unique --onetime $ifup\""
 
     # We have some specific interfaces to handle
     if [ -n "${RAW_IFACES}${IFACES}" ]; then


### PR DESCRIPTION
The original behavior of $env{INTERFACE} was undocumented and changed in
the recent udev versions, breaking the ability to bring up networking
reliably. Switching to $name directive should fix this issue.

Related links:
 - systemd/systemd#12700 (udev PR)
 - systemd/systemd#12291 (related udev issue)
 - systemd/systemd#14935 (this issue, udev side)
 - #732 (this issue, dracut side)

Fixes: #732
(cherry picked from commit a8ba1c4e25051c3c482bb7a6a754c9d785463917)