### PR TITLE
Add wicked specific config files (bsc#1089333)

### DIFF
--- a/modules.d/35network-legacy/module-setup.sh
+++ b/modules.d/35network-legacy/module-setup.sh
@@ -46,6 +46,12 @@ install() {
     inst_hook cmdline 99 "$moddir/parse-ifname.sh"
     inst_hook cleanup 10 "$moddir/kill-dhclient.sh"
 
+    # SUSE specific files
+    inst_multiple /etc/sysconfig/network/ifcfg-*
+    inst_multiple -o /etc/sysconfig/network/ifroute-*
+    inst_simple /etc/sysconfig/network/routes
+    inst_multiple -o /var/lib/wicked/duid.xml /var/lib/wicked/iaid.xml
+
     # install all config files for teaming
     unset TEAM_MASTER
     unset TEAM_CONFIG


### PR DESCRIPTION
Adding wickedd duid.xml and iaid.xml if available allows to present the same
identity to the dhcp server, and thus retaining the IP address assigned during
initrd phase in the regular system.