### PR TITLE
99base: enable the initqueue in both 'dracut --add-device' and 'dracu…

### DIFF
--- a/modules.d/99base/module-setup.sh
+++ b/modules.d/99base/module-setup.sh
@@ -97,7 +97,7 @@ install() {
 
     ## save host_devs which we need bring up
     if [[ $hostonly_cmdline == "yes" ]]; then
-        if [[ -n $add_device ]]; then
+        if [[ -n "${host_devs[@]}" ]]; then
             dracut_need_initqueue
         fi
         if [[ -f "$initdir/lib/dracut/need-initqueue" ]] || ! dracut_module_included "systemd"; then


### PR DESCRIPTION
…t --mount' cases.

The commit 9f3c31cd8d68 ("99base: enable initqueue if extra devices are added")
only covers 'dracut --add-device' case, but it did not cover 'dracut --mount'
case, which causes the kdump failure in the Amazon virtual machine.

Lets make sure that the initqueue is enabled in both cases in order to wake up
the device in time.

Reported-by: Xiao Liang <xiliang@redhat.com>
Signed-off-by: Lianbo Jiang <lijiang@redhat.com>
(cherry picked from commit 84c862d8f3993c93a3e90c70e7a05fdd8ca4a86f)

[tblume: bsc#1161573]