### PR TITLE
91zipl: parse-zipl.sh: honor SYSTEMD_READY

### DIFF
--- a/modules.d/91zipl/parse-zipl.sh
+++ b/modules.d/91zipl/parse-zipl.sh
@@ -31,7 +31,7 @@ if [ -n "$zipl_arg" ] ; then
     esac
     if [ "$zipl_env" ] ; then
         {
-            printf 'ACTION=="add|change", SUBSYSTEM=="block", %s=="%s", RUN+="/sbin/initqueue --settled --onetime --unique --name install_zipl_cmdline /sbin/install_zipl_cmdline.sh %s"\n' \
+            printf 'ACTION=="add|change", SUBSYSTEM=="block", %s=="%s", ENV{SYSTEMD_READY}!="0", RUN+="/sbin/initqueue --settled --onetime --unique --name install_zipl_cmdline /sbin/install_zipl_cmdline.sh %s"\n' \
                 ${zipl_env} ${zipl_val} ${zipl_arg}
             echo "[ -f /tmp/install.zipl.cmdline-done ]" >$hookdir/initqueue/finished/wait-zipl-conf.sh
         } >> /etc/udev/rules.d/99zipl-conf.rules


### PR DESCRIPTION
The zipl partition should not be mounted if SYSTEMD_READY=0 is set.
Otherwise booting issues with multipath will result.

Bug fix for bsc#1165828.