### PR TITLE
35network-legacy: correct conditional for creating did-setup file

### DIFF
--- a/modules.d/35network-legacy/ifup.sh
+++ b/modules.d/35network-legacy/ifup.sh
@@ -664,7 +664,7 @@ if [ -z "$NO_AUTO_DHCP" ] && [ ! -e /tmp/net.${netif}.up ]; then
             do_dhcp -4
         fi
     fi
-    if [ $? -eq 0 ] && [ -z "$(ls /tmp/leaseinfo.${netif}*)" ]; then
+    if [ $? -eq 0 ] && [ -n "$(ls /tmp/leaseinfo.${netif}*)" ]; then
          > /tmp/net.${netif}.did-setup
          if [ -e /sys/class/net/${netif}/address ]; then
              > /tmp/net.$(cat /sys/class/net/${netif}/address).did-setup


### PR DESCRIPTION
patch update on top of 6f5195cfcfa055d6b3788093578f8889277dcc5a
fixes bsc#1172807