### PR TITLE
net-lib.sh: support infiniband network mac addresses

### DIFF
--- a/modules.d/40network/net-lib.sh
+++ b/modules.d/40network/net-lib.sh
@@ -572,6 +572,11 @@ parse_ifname_opts() {
             # udev requires MAC addresses to be lower case
             ifname_mac=$(echo $2:$3:$4:$5:$6:$7 | sed 'y/ABCDEF/abcdef/')
             ;;
+        21)
+            ifname_if=$1
+            # udev requires MAC addresses to be lower case
+            ifname_mac=$(echo $2:$3:$4:$5:$6:$7:$8:$9:${10}:${11}:${12}:${13}:${14}:${15}:${16}:${17}:${18}:${19}:${20}:${21} | sed 'y/ABCDEF/abcdef/')
+            ;;
         *)
             die "Invalid arguments for ifname="
             ;;


### PR DESCRIPTION
Infiniband MAC addresses have 20 octets.

Reference: bsc#996146
(cherry picked from commit 376ce85105121936666349aa5a777768d52516f7)